### PR TITLE
Add downloads for 0.14.0-incubating

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -44,6 +44,27 @@
       </thead>
       <tbody>
         <tr>
+          <th scope="row">0.14.0-incubating</th>
+          <td>09 Apr 2019</td>
+          <td>
+            <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz');">source</a>
+
+            (<a href="https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.sha512" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.sha512');">sha512</a>
+
+            <a href="https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.asc" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.asc');">pgp</a>)
+          </td>
+          <td>
+            <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz');">binary</a>
+
+            (<a href="https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.sha512" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.sha512');">sha512</a>
+
+            <a href="https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.asc" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.asc');">pgp</a>)
+          </td>
+          <td>
+            <a href="https://github.com/apache/incubator-druid/releases/tag/druid-0.14.0-incubating">Release notes</a>
+          </td>
+        </tr>        
+        <tr>
           <th scope="row">0.13.0-incubating</th>
           <td>18 Dec 2018</td>
           <td>


### PR DESCRIPTION
Please do not merge yet, waiting 24 hours for release artifacts to propagate across mirrors.

Adds 0.14.0-incubating links to the download page.

