### PR TITLE
0.14.2 download link, change older releases to use archive links

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -91,7 +91,7 @@
 
     <br />
     <p>You should verify your download by following these <a href="https://www.apache.org/info/verification.html">procedures</a> and using these <a href="https://www.apache.org/dist/incubator/druid/KEYS">KEYS</a>.</p>
-    <p>All previous Apache releases of Druid are available at the <a href="https://archive.apache.org/dist/incubator/druid/">Apache release archives</a>.
+    <p>All previous releases of Apache Druid are available at the <a href="https://archive.apache.org/dist/incubator/druid/">Apache release archives</a>.
   </div>
   </div>
   </div>

--- a/downloads.html
+++ b/downloads.html
@@ -44,64 +44,85 @@
         </tr>
       </thead>
       <tbody>
-          <tr>
-              <th scope="row">0.14.1-incubating</th>
-              <td>09 May 2019</td>
-              <td>
-                <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz');">source</a>
-    
-                (<a href="https://www.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz.sha512" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz.sha512');">sha512</a>
-    
-                <a href="https://www.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz.asc" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz.asc');">pgp</a>)
-              </td>
-              <td>
-                <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz');">binary</a>
-    
-                (<a href="https://www.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz.sha512" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz.sha512');">sha512</a>
-    
-                <a href="https://www.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz.asc" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz.asc');">pgp</a>)
-              </td>
-              <td>
-                <a href="https://github.com/apache/incubator-druid/releases/tag/druid-0.14.1-incubating">Release notes</a>
-              </td>
-            </tr>   
         <tr>
-          <th scope="row">0.14.0-incubating</th>
-          <td>09 Apr 2019</td>
+          <th scope="row">0.14.2-incubating</th>
+          <td>25 May 2019</td>
           <td>
-            <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz');">source</a>
+            <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-src.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.2-incubating/apache-druid-0.14.1-incubating-src.tar.gz');">source</a>
 
-            (<a href="https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.sha512" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.sha512');">sha512</a>
+            (<a href="https://www.apache.org/dist/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-src.tar.gz.sha512" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-src.tar.gz.sha512');">sha512</a>
 
-            <a href="https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.asc" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.asc');">pgp</a>)
+            <a href="https://www.apache.org/dist/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-src.tar.gz.asc" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-src.tar.gz.asc');">pgp</a>)
           </td>
           <td>
-            <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz');">binary</a>
+            <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-bin.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-bin.tar.gz');">binary</a>
 
-            (<a href="https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.sha512" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.sha512');">sha512</a>
+            (<a href="https://www.apache.org/dist/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-bin.tar.gz.sha512" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-bin.tar.gz.sha512');">sha512</a>
 
-            <a href="https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.asc" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.asc');">pgp</a>)
+            <a href="https://www.apache.org/dist/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-bin.tar.gz.asc" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-bin.tar.gz.asc');">pgp</a>)
           </td>
           <td>
-            <a href="https://github.com/apache/incubator-druid/releases/tag/druid-0.14.0-incubating">Release notes</a>
+            <a href="https://github.com/apache/incubator-druid/releases/tag/druid-0.14.2-incubating">Release notes</a>
           </td>
-        </tr>        
+        </tr>
+        <tr>
+          <th scope="row">0.14.1-incubating</th>
+          <td>09 May 2019</td>
+          <td>
+            <a href="https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz');">source</a>
+
+            (<a href="https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz.sha512" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz.sha512');">sha512</a>
+
+            <a href="https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz.asc" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz.asc');">pgp</a>)
+          </td>
+          <td>
+            <a href="https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz');">binary</a>
+
+            (<a href="https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz.sha512" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz.sha512');">sha512</a>
+
+            <a href="https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz.asc" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz.asc');">pgp</a>)
+          </td>
+          <td>
+            <a href="https://github.com/apache/incubator-druid/releases/tag/druid-0.14.1-incubating">Release notes</a>
+          </td>
+        </tr>   
+    <tr>
+      <th scope="row">0.14.0-incubating</th>
+      <td>09 Apr 2019</td>
+      <td>
+        <a href="https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz');">source</a>
+
+        (<a href="https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.sha512" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.sha512');">sha512</a>
+
+        <a href="https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.asc" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.asc');">pgp</a>)
+      </td>
+      <td>
+        <a href="https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz');">binary</a>
+
+        (<a href="https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.sha512" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.sha512');">sha512</a>
+
+        <a href="https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.asc" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.asc');">pgp</a>)
+      </td>
+      <td>
+        <a href="https://github.com/apache/incubator-druid/releases/tag/druid-0.14.0-incubating">Release notes</a>
+      </td>
+    </tr>
         <tr>
           <th scope="row">0.13.0-incubating</th>
           <td>18 Dec 2018</td>
           <td>
-            <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz');">source</a>
+            <a href="https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz" onclick="trackDownload('click', ' https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz');">source</a>
 
-            (<a href="https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.sha512" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.sha512');">sha512</a>
+            (<a href="https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.sha512" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.sha512');">sha512</a>
 
-            <a href="https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.asc" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.asc');">pgp</a>)
+            <a href="https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.asc" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.asc');">pgp</a>)
           </td>
           <td>
-            <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz');">binary</a>
+            <a href="https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz');">binary</a>
 
-            (<a href="https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.sha512" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.sha512');">sha512</a>
+            (<a href="https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.sha512" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.sha512');">sha512</a>
 
-            <a href="https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.asc" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.asc');">pgp</a>)
+            <a href="https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.asc" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.asc');">pgp</a>)
           </td>
           <td>
             <a href="https://github.com/apache/incubator-druid/releases/tag/druid-0.13.0-incubating">Release notes</a>

--- a/downloads.html
+++ b/downloads.html
@@ -46,7 +46,7 @@
       <tbody>
         <tr>
           <th scope="row">0.14.2-incubating</th>
-          <td>26 May 2019</td>
+          <td>27 May 2019</td>
           <td>
             <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-src.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.2-incubating/apache-druid-0.14.1-incubating-src.tar.gz');">source</a>
 

--- a/downloads.html
+++ b/downloads.html
@@ -46,7 +46,7 @@
       <tbody>
         <tr>
           <th scope="row">0.14.2-incubating</th>
-          <td>25 May 2019</td>
+          <td>26 May 2019</td>
           <td>
             <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.2-incubating/apache-druid-0.14.2-incubating-src.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.14.2-incubating/apache-druid-0.14.1-incubating-src.tar.gz');">source</a>
 

--- a/downloads.html
+++ b/downloads.html
@@ -91,7 +91,7 @@
 
     <br />
     <p>You should verify your download by following these <a href="https://www.apache.org/info/verification.html">procedures</a> and using these <a href="https://www.apache.org/dist/incubator/druid/KEYS">KEYS</a>.</p>
-    <p>All previous releases of Apache Druid are available at the <a href="https://archive.apache.org/dist/incubator/druid/">Apache release archives</a>.
+    <p>All other releases of Apache Druid are available at the <a href="https://archive.apache.org/dist/incubator/druid/">Apache release archives</a>.
   </div>
   </div>
   </div>

--- a/downloads.html
+++ b/downloads.html
@@ -66,63 +66,21 @@
           </td>
         </tr>
         <tr>
-          <th scope="row">0.14.1-incubating</th>
-          <td>09 May 2019</td>
-          <td>
-            <a href="https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz');">source</a>
-
-            (<a href="https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz.sha512" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz.sha512');">sha512</a>
-
-            <a href="https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz.asc" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-src.tar.gz.asc');">pgp</a>)
-          </td>
-          <td>
-            <a href="https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz');">binary</a>
-
-            (<a href="https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz.sha512" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz.sha512');">sha512</a>
-
-            <a href="https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz.asc" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.1-incubating/apache-druid-0.14.1-incubating-bin.tar.gz.asc');">pgp</a>)
-          </td>
-          <td>
-            <a href="https://github.com/apache/incubator-druid/releases/tag/druid-0.14.1-incubating">Release notes</a>
-          </td>
-        </tr>   
-    <tr>
-      <th scope="row">0.14.0-incubating</th>
-      <td>09 Apr 2019</td>
-      <td>
-        <a href="https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz');">source</a>
-
-        (<a href="https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.sha512" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.sha512');">sha512</a>
-
-        <a href="https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.asc" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-src.tar.gz.asc');">pgp</a>)
-      </td>
-      <td>
-        <a href="https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz');">binary</a>
-
-        (<a href="https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.sha512" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.sha512');">sha512</a>
-
-        <a href="https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.asc" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.14.0-incubating/apache-druid-0.14.0-incubating-bin.tar.gz.asc');">pgp</a>)
-      </td>
-      <td>
-        <a href="https://github.com/apache/incubator-druid/releases/tag/druid-0.14.0-incubating">Release notes</a>
-      </td>
-    </tr>
-        <tr>
           <th scope="row">0.13.0-incubating</th>
           <td>18 Dec 2018</td>
           <td>
-            <a href="https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz" onclick="trackDownload('click', ' https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz');">source</a>
+            <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz');">source</a>
 
-            (<a href="https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.sha512" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.sha512');">sha512</a>
+            (<a href="https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.sha512" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.sha512');">sha512</a>
 
-            <a href="https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.asc" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.asc');">pgp</a>)
+            <a href="https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.asc" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-src.tar.gz.asc');">pgp</a>)
           </td>
           <td>
-            <a href="https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz');">binary</a>
+            <a href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz" onclick="trackDownload('click', 'https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz');">binary</a>
 
-            (<a href="https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.sha512" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.sha512');">sha512</a>
+            (<a href="https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.sha512" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.sha512');">sha512</a>
 
-            <a href="https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.asc" onclick="trackDownload('click', 'https://archive.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.asc');">pgp</a>)
+            <a href="https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.asc" onclick="trackDownload('click', 'https://www.apache.org/dist/incubator/druid/0.13.0-incubating/apache-druid-0.13.0-incubating-bin.tar.gz.asc');">pgp</a>)
           </td>
           <td>
             <a href="https://github.com/apache/incubator-druid/releases/tag/druid-0.13.0-incubating">Release notes</a>
@@ -132,7 +90,8 @@
     </table>
 
     <br />
-    <p>You should verify your download by following these <a href="https://www.apache.org/info/verification.html">procedures</a> and using these <a href="https://www.apache.org/dist/incubator/druid/KEYS">KEYS</a>.
+    <p>You should verify your download by following these <a href="https://www.apache.org/info/verification.html">procedures</a> and using these <a href="https://www.apache.org/dist/incubator/druid/KEYS">KEYS</a>.</p>
+    <p>All previous Apache releases of Druid are available at the <a href="https://archive.apache.org/dist/incubator/druid/">Apache release archives</a>.
   </div>
   </div>
   </div>


### PR DESCRIPTION
Adds download for 0.14.2-incubating release, adds link to `archive.apache.org` so we can remove older releases from mirrors. 

<img width="1315" alt="Screen Shot 2019-05-26 at 4 13 50 PM" src="https://user-images.githubusercontent.com/1577461/58388244-45f3aa80-7fd1-11e9-9298-99124021ed52.png">
