### PR TITLE
Spelling Error

### DIFF
--- a/docs/0.15.0-incubating/tutorials/cluster.html
+++ b/docs/0.15.0-incubating/tutorials/cluster.html
@@ -554,7 +554,7 @@ rather than on the Master server.
 <p>If you have been editing the configurations on your local machine, you can use <em>rsync</em> to copy them:</p>
 <div class="highlight"><pre><code class="language-bash" data-lang="bash"><span></span>rsync -az apache-druid-0.15.0-incubating/ MASTER_SERVER:apache-druid-0.15.0-incubating/
 </code></pre></div>
-<h3 id="no-zookeper-on-master">No Zookeper on Master</h3>
+<h3 id="no-zookeper-on-master">No Zookeeper on Master</h3>
 
 <p>From the distribution root, run the following command to start the Master server:</p>
 <div class="highlight"><pre><code class="language-text" data-lang="text"><span></span>bin/start-cluster-master-no-zk-server


### PR DESCRIPTION
I came across this while reading the docs

https://github.com/apache/incubator-druid-website-src/blob/master/docs/0.15.0-incubating/tutorials/cluster.md