### PR TITLE
add .asf.yaml to have staging site from branch asf-staging

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,9 @@
+# Staging and publishing profile for incubator-druid-website.git:
+
+staging:
+  profile: ~
+  whoami:  asf-staging
+
+
+publish:
+  whoami:  asf-site


### PR DESCRIPTION
add staging website via [.asf.yaml](https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories) where `asf-staging` branch is currently populated with `druid-0.16.0-incubating-rc1` docs.